### PR TITLE
Update currency labeling and version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "currencyconverter3",
-  "version": "0.1.0",
+  "version": "3.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "currencyconverter3",
-      "version": "0.1.0",
+      "version": "3.2.2",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "currencyconverter3",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",

--- a/src/App.css
+++ b/src/App.css
@@ -42,7 +42,7 @@ body {
 }
 
 .container {
-  padding-top: 20px;
+  padding-top: 60px;
 }
 
 body.dark {

--- a/src/compononents/Currency.js
+++ b/src/compononents/Currency.js
@@ -191,7 +191,7 @@ function Currency() {
             >
               {currencyCodes.map((code) => (
                 <option key={code} value={code}>
-                  {getSymbol(code)}
+                  {`${getSymbol(code)} (${code})`}
                 </option>
               ))}
             </select>
@@ -209,7 +209,7 @@ function Currency() {
             >
               {currencyCodes.map((code) => (
                 <option key={code} value={code}>
-                  {getSymbol(code)}
+                  {`${getSymbol(code)} (${code})`}
                 </option>
               ))}
             </select>
@@ -224,8 +224,8 @@ function Currency() {
         onChange={(e) => handleDateSelection(e)}
       />
       <p>
-        1 {getSymbol(firstCurrency)} = <span id="currencyRateText" />
-        <strong>{currencyRate}</strong> {getSymbol(secondCurrency)}
+        1 {getSymbol(firstCurrency)} ({firstCurrency}) = <span id="currencyRateText" />
+        <strong>{currencyRate}</strong> {getSymbol(secondCurrency)} ({secondCurrency})
       </p>
     </div>
   );

--- a/src/compononents/Footer.js
+++ b/src/compononents/Footer.js
@@ -5,7 +5,7 @@ function Footer() {
     <footer>
       <div className="footer">
         <p>Developed by Mustafa Evleksiz</p>
-        <p>© 2024 CC v3.2.1</p>
+        <p>© 2025 CC v3.2.2</p>
         <p>
           Exchange rates from{' '}
           <a href="https://frankfurter.dev" target="_blank" rel="noreferrer">


### PR DESCRIPTION
## Summary
- bump app version
- pad content from the top
- show currency codes next to symbols
- update footer year

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687ab74037cc83279ce4aedf76b5b5a7