### PR TITLE
Implement UI tweaks and bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "currencyconverter3",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "currencyconverter3",
-      "version": "3.2.2",
+      "version": "3.2.3",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "currencyconverter3",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",

--- a/src/App.css
+++ b/src/App.css
@@ -46,7 +46,7 @@ body {
 }
 
 body.dark {
-  background-color: #121212;
+  background-color: #2a2a2a;
   color: #f1f1f1;
 }
 
@@ -73,7 +73,7 @@ body.dark {
 }
 
 body.dark .currencyDiv {
-  background-color: #1e1e1e;
+  background-color: #3a3a3a;
   color: #f1f1f1;
 }
 
@@ -118,6 +118,7 @@ input[type="date"] {
   border-radius: 0;
   width: 100%;
   padding: 10px 0;
+  margin-top: 15px;
   margin-bottom: 20px;
   font-size: 16px;
   color: #444;
@@ -199,7 +200,7 @@ button {
 }
 
 body.dark .footer {
-  background-color: #000000;
+  background-color: #111111;
   border-top-color: #ffffff;
 }
 
@@ -210,4 +211,11 @@ body.dark .footer {
 
 .footer a {
   color: #61dafb;
+}
+
+.plusIcon {
+  text-align: center;
+  font-size: 2rem;
+  opacity: 0.5;
+  margin-top: 10px;
 }

--- a/src/compononents/Currency.js
+++ b/src/compononents/Currency.js
@@ -227,6 +227,7 @@ function Currency() {
         1 {getSymbol(firstCurrency)} ({firstCurrency}) = <span id="currencyRateText" />
         <strong>{currencyRate}</strong> {getSymbol(secondCurrency)} ({secondCurrency})
       </p>
+      <div className="plusIcon">➕</div>
     </div>
   );
 }

--- a/src/compononents/Footer.js
+++ b/src/compononents/Footer.js
@@ -5,7 +5,7 @@ function Footer() {
     <footer>
       <div className="footer">
         <p>Developed by Mustafa Evleksiz</p>
-        <p>© 2025 CC v3.2.2</p>
+        <p>© 2025 CC v3.2.3</p>
         <p>
           Exchange rates from{' '}
           <a href="https://frankfurter.dev" target="_blank" rel="noreferrer">


### PR DESCRIPTION
## Summary
- add semi-transparent plus icon under currency rate
- push date field down slightly
- lighten dark mode backgrounds
- bump version to 3.2.3 in package files and footer

## Testing
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_687abb22c3488327984af353b76cb480