### PR TITLE
UI tweaks and dynamic version script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "currencyconverter3",
-  "version": "7.18.2221",
+  "version": "7.18.2245",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "currencyconverter3",
-      "version": "7.18.2221",
+      "version": "7.18.2245",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "currencyconverter3",
-  "version": "7.18.2221",
+  "version": "7.18.2245",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",
@@ -15,7 +15,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "update-version": "node scripts/updateVersion.js"
   },
   "eslintConfig": {
     "extends": [

--- a/scripts/updateVersion.js
+++ b/scripts/updateVersion.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const path = require('path');
+
+function getVersion() {
+  const now = new Date();
+  const month = now.getMonth() + 1; // 1-12
+  const day = now.getDate();
+  const hours = String(now.getHours()).padStart(2, '0');
+  const minutes = String(now.getMinutes()).padStart(2, '0');
+  return `${month}.${day}.${hours}${minutes}`;
+}
+
+const version = getVersion();
+
+const root = path.join(__dirname, '..');
+const pkgPath = path.join(root, 'package.json');
+const pkgLockPath = path.join(root, 'package-lock.json');
+const footerPath = path.join(root, 'src', 'compononents', 'Footer.js');
+
+function updateJSON(filePath, handler) {
+  const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  handler(data);
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2) + '\n');
+}
+
+updateJSON(pkgPath, (data) => { data.version = version; });
+updateJSON(pkgLockPath, (data) => {
+  data.version = version;
+  if (data.packages && data.packages['']) {
+    data.packages[''].version = version;
+  }
+});
+
+let footerContent = fs.readFileSync(footerPath, 'utf8');
+footerContent = footerContent.replace(/v\d+\.\d+\.\d+/g, `v${version}`);
+fs.writeFileSync(footerPath, footerContent);
+
+console.log(`Version updated to ${version}`);

--- a/src/App.css
+++ b/src/App.css
@@ -169,6 +169,10 @@ select {
   margin-bottom: 10px;
 }
 
+.currencyRow input[type="number"] {
+  width: 60%;
+}
+
 button {
   width: 100%;
   font-size: 1.2rem;
@@ -216,7 +220,6 @@ body.dark .footer {
 .plusIcon {
   text-align: center;
   font-size: 2rem;
-  opacity: 0.5;
   margin-top: 10px;
   color: green;
   cursor: pointer;

--- a/src/compononents/Currency.js
+++ b/src/compononents/Currency.js
@@ -174,6 +174,12 @@ function Currency() {
     );
   };
 
+  const handleRemoveCurrency = (index) => {
+    if (window.confirm("Remove currency?")) {
+      setCurrencies((prev) => prev.filter((_, i) => i !== index));
+    }
+  };
+
   return (
     <div className="currencyDiv">
       <h1>💰Currency Calculator</h1>
@@ -200,14 +206,10 @@ function Currency() {
                   </option>
                 ))}
               </select>
-              {idx > 0 && currencies.length >= 3 && (
+              {currencies.length >= 3 && (
                 <span
                   className="minusIcon"
-                  onClick={() => {
-                    if (window.confirm("Remove currency?")) {
-                      setCurrencies((prev) => prev.filter((_, i) => i !== idx));
-                    }
-                  }}
+                  onClick={() => handleRemoveCurrency(idx)}
                 >
                   ➖
                 </span>
@@ -241,6 +243,11 @@ function Currency() {
           )}
         </div>
       </div>
+      {currencies.length < 6 && (
+        <div className="plusIcon" onClick={() => setShowAdd(!showAdd)}>
+          ➕
+        </div>
+      )}
       <input
         type="date"
         name="oldDateOther"
@@ -253,11 +260,6 @@ function Currency() {
           1 {getSymbol(currencies[0].code)} ({currencies[0].code}) ={' '}
           <strong>{currencies[1].rate}</strong> {getSymbol(currencies[1].code)} ({currencies[1].code})
         </p>
-      )}
-      {currencies.length < 6 && (
-        <div className="plusIcon" onClick={() => setShowAdd(!showAdd)}>
-          ➕
-        </div>
       )}
     </div>
   );

--- a/src/compononents/Footer.js
+++ b/src/compononents/Footer.js
@@ -5,7 +5,7 @@ function Footer() {
     <footer>
       <div className="footer">
         <p>Developed by Mustafa Evleksiz</p>
-        <p>© 2025 CC v7.18.2221</p>
+        <p>© 2025 CC v7.18.2245</p>
         <p>
           Exchange rates from{' '}
           <a href="https://frankfurter.dev" target="_blank" rel="noreferrer">


### PR DESCRIPTION
## Summary
- allow removing the base currency when at least three currencies are selected
- reposition the add-currency button above the date field
- color-coded plus/minus icons without transparency
- shrink number input width for more space
- add script to update package versions based on current date and time

## Testing
- `npm install`
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_687acd766ba0832784316277c0c9c9c6