### PR TITLE
UI tweaks and date navigation improvements

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -42,7 +42,7 @@ body {
 }
 
 .container {
-  padding-top: 60px;
+  padding-top: 100px;
 }
 
 body.dark {
@@ -51,10 +51,9 @@ body.dark {
 }
 
 .logo {
-  width: 50px;
-  position: absolute;
-  top: 10px;
-  left: 10px;
+  width: 100px;
+  display: block;
+  margin: 0 auto;
   cursor: pointer;
 }
 
@@ -121,15 +120,15 @@ body.dark .currencyDiv {
 }
 
 input[type="date"] {
-  border: none;
-  border-bottom: 2px solid #6c5ce7;
-  border-radius: 0;
+  border: 1px solid #6c5ce7;
+  border-radius: 4px;
   width: 100%;
-  padding: 10px 0;
+  padding: 8px 12px;
   margin-top: 15px;
   margin-bottom: 20px;
   font-size: 16px;
   color: #444;
+  background-color: #f8f8f8;
 }
 
 input[type="number"] {
@@ -243,6 +242,8 @@ body.dark .footer {
   margin-left: 10px;
   cursor: pointer;
   transition: transform 0.2s ease;
+  width: auto;
+  padding: 5px 10px;
 }
 
 .minusIcon:hover {
@@ -275,6 +276,6 @@ body.dark .footer {
 }
 
 .dateNavigator button:disabled {
-  opacity: 0.5;
+  opacity: 0.25;
   cursor: not-allowed;
 }

--- a/src/compononents/Currency.js
+++ b/src/compononents/Currency.js
@@ -119,16 +119,8 @@ function Currency({ isSuper }) {
   const [baseIndex, setBaseIndex] = useState(0);
 
   const nextDayDisabled = currencyTime >= today;
-  const nextMonthDisabled = (() => {
-    const d = new Date(currencyTime);
-    d.setMonth(d.getMonth() + 1);
-    return d.toISOString().slice(0, 10) > today;
-  })();
-  const nextYearDisabled = (() => {
-    const d = new Date(currencyTime);
-    d.setFullYear(d.getFullYear() + 1);
-    return d.toISOString().slice(0, 10) > today;
-  })();
+  const nextMonthDisabled = currencyTime >= today;
+  const nextYearDisabled = currencyTime >= today;
 
   const changeDate = (days) => {
     const d = new Date(currencyTime);
@@ -142,7 +134,10 @@ function Currency({ isSuper }) {
     const d = new Date(currencyTime);
     d.setMonth(d.getMonth() + months);
     const newDate = d.toISOString().slice(0, 10);
-    if (newDate > today) return;
+    if (months > 0 && newDate > today) {
+      handleDateSelection({ target: { value: today } });
+      return;
+    }
     handleDateSelection({ target: { value: newDate } });
   };
 
@@ -150,7 +145,10 @@ function Currency({ isSuper }) {
     const d = new Date(currencyTime);
     d.setFullYear(d.getFullYear() + years);
     const newDate = d.toISOString().slice(0, 10);
-    if (newDate > today) return;
+    if (years > 0 && newDate > today) {
+      handleDateSelection({ target: { value: today } });
+      return;
+    }
     handleDateSelection({ target: { value: newDate } });
   };
 


### PR DESCRIPTION
## Summary
- resize and center logo
- tweak date input styling and disabled button opacity
- narrow remove buttons
- adjust forward button logic to clamp to today

## Testing
- `npm test --silent` *(fails: No tests found related to files changed since last commit)*

------
https://chatgpt.com/codex/tasks/task_e_687b9617fcc4832793a1b656346ae70c