### PR TITLE
UI and input improvements

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -42,7 +42,7 @@ body {
 }
 
 .container {
-  padding-top: 100px;
+  padding-top: 60px;
 }
 
 body.dark {
@@ -50,10 +50,26 @@ body.dark {
   color: #f1f1f1;
 }
 
+.logo-band {
+  width: 100%;
+  background-color: #ffffff;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 5px 0;
+  margin-bottom: 10px;
+  border-radius: 10px;
+}
+
+body.dark .logo-band {
+  background-color: #333333;
+}
+
 .logo {
-  width: 300px;
+  width: 350px;
+  height: 60px;
   display: block;
-  margin: 0 auto 20px;
+  object-fit: contain;
   cursor: default;
   user-select: none;
 }
@@ -179,14 +195,6 @@ select {
   appearance: none;
 }
 
-.dropdown::after {
-  content: "\25BC";
-  position: absolute;
-  top: 50%;
-  right: 10px;
-  transform: translateY(-50%);
-  color: #6c5ce7;
-}
 
 .dropdown {
   position: relative;
@@ -302,4 +310,8 @@ body.dark .footer {
 .dateNavigator button:disabled {
   opacity: 0.25;
   cursor: not-allowed;
+}
+
+.react-datepicker-popper {
+  z-index: 100;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -33,7 +33,9 @@ function App() {
 
   return (
     <div className="container">
-      <img src={logo} alt="logo" className="logo" onClick={handleLogoClick} />
+      <div className="logo-band">
+        <img src={logo} alt="logo" className="logo" onClick={handleLogoClick} />
+      </div>
       {superMode && (
         <button className="themeToggle" onClick={toggleTheme}>
           {theme === "dark" ? "☀️" : "🌙"}

--- a/src/compononents/Currency.js
+++ b/src/compononents/Currency.js
@@ -192,9 +192,14 @@ function Currency({ isSuper }) {
       if (typeof val === "string") {
         const upper = val.trim().toUpperCase();
         if (upper === "M") return 1000000;
+        if (upper === "K") return 1000;
         if (upper.endsWith("M")) {
           const num = parseFloat(upper.slice(0, -1));
           return (isNaN(num) ? 1 : num) * 1000000;
+        }
+        if (upper.endsWith("K")) {
+          const num = parseFloat(upper.slice(0, -1));
+          return (isNaN(num) ? 1 : num) * 1000;
         }
       }
       const num = parseFloat(val);
@@ -247,12 +252,6 @@ function Currency({ isSuper }) {
                 animate={{ opacity: 1, y: 0 }}
                 exit={{ opacity: 0, y: 10 }}
               >
-                <Form.Control
-                  type="text"
-                  value={c.amount}
-                  onFocus={() => setBaseIndex(idx)}
-                  onChange={(e) => handleAmountChange(idx, e.target.value)}
-                />
                 <Form.Select
                   value={c.code}
                   onChange={(e) => handleCurrencyChange(idx, e.target.value)}
@@ -263,6 +262,23 @@ function Currency({ isSuper }) {
                     </option>
                   ))}
                 </Form.Select>
+                <Form.Control
+                  type="text"
+                  inputMode="decimal"
+                  pattern="[0-9]*"
+                  value={c.amount}
+                  onKeyDown={(e) => {
+                    const key = e.key.toLowerCase();
+                    if (key === "m" || key === "k") {
+                      e.preventDefault();
+                      const zeros = key === "m" ? "000000" : "000";
+                      const cleaned = String(e.target.value).replace(/\D/g, "");
+                      handleAmountChange(idx, cleaned + zeros);
+                    }
+                  }}
+                  onFocus={() => setBaseIndex(idx)}
+                  onChange={(e) => handleAmountChange(idx, e.target.value)}
+                />
                 {currencies.length >= 3 && (
                   <Button
                     variant="danger"


### PR DESCRIPTION
## Summary
- style logo inside new band and reduce vertical gaps
- remove dropdown arrow and add DatePicker z-index
- support k/m shortcuts for amounts and show numeric keyboard
- reorder currency rows with currency selector first

## Testing
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_687bb4e24be083278ea9651967a6d19a