### PR TITLE
UI tweaks

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -42,7 +42,7 @@ body {
 }
 
 .container {
-  padding-top: 60px;
+  padding-top: 20px;
 }
 
 body.dark {
@@ -50,29 +50,6 @@ body.dark {
   color: #f1f1f1;
 }
 
-.logo-band {
-  width: 100%;
-  background-color: #ffffff;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: 5px 0;
-  margin-bottom: 10px;
-  border-radius: 10px;
-}
-
-body.dark .logo-band {
-  background-color: #333333;
-}
-
-.logo {
-  width: 350px;
-  height: 60px;
-  display: block;
-  object-fit: contain;
-  cursor: default;
-  user-select: none;
-}
 
 .currencyContainer {
   display: flex;
@@ -163,6 +140,26 @@ input[type="date"] {
   font-size: 16px;
   background-color: #f8f8f8;
   color: inherit;
+}
+
+.react-datepicker {
+  background-color: #333;
+  border: 1px solid #555;
+  color: #fff;
+}
+
+.react-datepicker__header {
+  background-color: #444;
+  border-bottom: 1px solid #555;
+}
+
+body.dark .react-datepicker {
+  background-color: #222;
+}
+
+body.dark .react-datepicker__header {
+  background-color: #333;
+  border-bottom: 1px solid #555;
 }
 
 body.dark .react-datepicker__input-container input {
@@ -258,7 +255,7 @@ body.dark .footer {
 
 .currencyDiv .plusIcon {
   text-align: center;
-  font-size: 2rem;
+  font-size: 1rem;
   margin-top: 10px;
   color: #0f9d58 !important;
   cursor: pointer;
@@ -314,4 +311,11 @@ body.dark .footer {
 
 .react-datepicker-popper {
   z-index: 100;
+}
+
+@media (max-width: 576px) {
+  .dateNavigator button {
+    font-size: 0.8rem;
+    padding: 2px 5px;
+  }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,6 @@
 import "./App.css";
 import Currency from "./compononents/Currency";
 import Footer from "./compononents/Footer";
-// import logo from "./logo.svg";
-import logo from "./logo.png"; // Adjust the path as necessary
 
 import { useEffect, useState } from "react";
 
@@ -10,14 +8,14 @@ function App() {
   const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
   const [theme, setTheme] = useState(prefersDark ? "dark" : "light");
   const [superMode, setSuperMode] = useState(false);
-  const [logoClicks, setLogoClicks] = useState(0);
+  const [titleClicks, setTitleClicks] = useState(0);
 
   const toggleTheme = () => {
     setTheme(theme === "dark" ? "light" : "dark");
   };
 
-  const handleLogoClick = () => {
-    setLogoClicks((prev) => {
+  const handleTitleClick = () => {
+    setTitleClicks((prev) => {
       const next = prev + 1;
       if (next >= 5) {
         setSuperMode((s) => !s);
@@ -33,15 +31,12 @@ function App() {
 
   return (
     <div className="container">
-      <div className="logo-band">
-        <img src={logo} alt="logo" className="logo" onClick={handleLogoClick} />
-      </div>
       {superMode && (
         <button className="themeToggle" onClick={toggleTheme}>
           {theme === "dark" ? "☀️" : "🌙"}
         </button>
       )}
-      <Currency isSuper={superMode} />
+      <Currency isSuper={superMode} onTitleClick={handleTitleClick} />
       <Footer />
     </div>
   );

--- a/src/compononents/Currency.js
+++ b/src/compononents/Currency.js
@@ -109,7 +109,7 @@ const fetchRate = async (from, to, date) => {
   return data.rates[to];
 };
 
-function Currency({ isSuper }) {
+function Currency({ isSuper, onTitleClick }) {
   const [currencies, setCurrencies] = useState([
     { code: "USD", amount: 1, rate: 1 },
     { code: "TRY", amount: 0, rate: 0 },
@@ -240,6 +240,7 @@ function Currency({ isSuper }) {
 
   return (
     <div className="currencyDiv">
+      <h1 onClick={onTitleClick}>Currency Calculator</h1>
       <div className="currencySelection">
         <div className="dropdown">
           <AnimatePresence>
@@ -341,6 +342,7 @@ function Currency({ isSuper }) {
             }
             maxDate={new Date()}
             dateFormat="yyyy-MM-dd"
+            showYearDropdown
           />
           <Button onClick={() => changeDate(1)} disabled={nextDayDisabled}>
             {">"}
@@ -362,6 +364,7 @@ function Currency({ isSuper }) {
           }
           maxDate={new Date()}
           dateFormat="yyyy-MM-dd"
+          showYearDropdown
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- remove logo bar and image
- show the title in the currency pane
- enable year dropdown on the date picker
- shrink add button
- dark theme for calendar and responsive date navigator buttons

## Testing
- `npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_687bba4015908327aa7f0a43155d3cc6