### PR TITLE
Add currency flag emojis

### DIFF
--- a/src/compononents/Currency.js
+++ b/src/compononents/Currency.js
@@ -46,6 +46,49 @@ const currencySymbols = {
   XPD: "Palladium (g)",
 };
 
+const currencyFlags = {
+  AUD: "\uD83C\uDDE6\uD83C\uDDFA", // Australia
+  BGN: "\uD83C\uDDE7\uD83C\uDDEC", // Bulgaria
+  BRL: "\uD83C\uDDE7\uD83C\uDDF7", // Brazil
+  CAD: "\uD83C\uDDE8\uD83C\uDDE6", // Canada
+  CHF: "\uD83C\uDDE8\uD83C\uDDED", // Switzerland
+  CNY: "\uD83C\uDDE8\uD83C\uDDF3", // China
+  CZK: "\uD83C\uDDE8\uD83C\uDDFF", // Czechia
+  DKK: "\uD83C\uDDE9\uD83C\uDDF0", // Denmark
+  EUR: "\uD83C\uDDEA\uD83C\uDDFA", // European Union
+  GBP: "\uD83C\uDDEC\uD83C\uDDE7", // United Kingdom
+  HKD: "\uD83C\uDDED\uD83C\uDDF0", // Hong Kong
+  HUF: "\uD83C\uDDED\uD83C\uDDFA", // Hungary
+  IDR: "\uD83C\uDDEE\uD83C\uDDE9", // Indonesia
+  ILS: "\uD83C\uDDEE\uD83C\uDDF1", // Israel
+  INR: "\uD83C\uDDEE\uD83C\uDDF3", // India
+  ISK: "\uD83C\uDDEE\uD83C\uDDF8", // Iceland
+  JPY: "\uD83C\uDDEF\uD83C\uDDF5", // Japan
+  KRW: "\uD83C\uDDF0\uD83C\uDDF7", // South Korea
+  MXN: "\uD83C\uDDF2\uD83C\uDDFD", // Mexico
+  MYR: "\uD83C\uDDF2\uD83C\uDDFE", // Malaysia
+  NOK: "\uD83C\uDDF3\uD83C\uDDF4", // Norway
+  NZD: "\uD83C\uDDF3\uD83C\uDDFF", // New Zealand
+  PHP: "\uD83C\uDDF5\uD83C\uDDED", // Philippines
+  PLN: "\uD83C\uDDF5\uD83C\uDDF1", // Poland
+  RON: "\uD83C\uDDF7\uD83C\uDDF4", // Romania
+  SEK: "\uD83C\uDDF8\uD83C\uDDEA", // Sweden
+  SGD: "\uD83C\uDDF8\uD83C\uDDEC", // Singapore
+  THB: "\uD83C\uDDF9\uD83C\uDDED", // Thailand
+  TRY: "\uD83C\uDDF9\uD83C\uDDF7", // Turkey
+  TRL: "\uD83C\uDDF9\uD83C\uDDF7", // Turkey
+  USD: "\uD83C\uDDFA\uD83C\uDDF8", // United States
+  ZAR: "\uD83C\uDDFF\uD83C\uDDE6", // South Africa
+  AED: "\uD83C\uDDE6\uD83C\uDDEA", // United Arab Emirates
+  SAR: "\uD83C\uDDF8\uD83C\uDDE6", // Saudi Arabia
+  XAU: "\uD83E\uDD47", // gold medal
+  XAG: "\uD83E\uDD48", // silver medal
+  XPT: "\uD83E\uDE99", // coin
+  XPD: "\u2699\uFE0F", // gear
+};
+
+const getFlag = (code) => currencyFlags[code] || "";
+
 const currencyCodes = [
   "AUD",
   "BGN",
@@ -349,7 +392,7 @@ function Currency({ isSuper, onTitleClick }) {
                 >
                   {currencyCodes.map((code) => (
                     <option key={code} value={code}>
-                      {`${getSymbol(code)} (${code})`}
+                      {`${getFlag(code)} ${getSymbol(code)} (${code})`}
                     </option>
                   ))}
                 </Form.Select>
@@ -402,7 +445,7 @@ function Currency({ isSuper, onTitleClick }) {
                 .filter((code) => !currencies.some((c) => c.code === code))
                 .map((code) => (
                   <option key={code} value={code}>
-                    {`${getSymbol(code)} (${code})`}
+                    {`${getFlag(code)} ${getSymbol(code)} (${code})`}
                   </option>
                 ))}
             </Form.Select>


### PR DESCRIPTION
## Summary
- show emoji flags next to currencies
- include metal icons for gold, silver, platinum, and palladium

## Testing
- `npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6883ae8cdb9c8327aed38daea90edf44