### PR TITLE
Update app branding and footer

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -46,6 +46,7 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  padding-bottom: 60px;
 }
 
 body.dark {
@@ -254,6 +255,9 @@ button {
   width: 100%;
   border-top: 1px solid #cccccc;
   margin-top: auto;
+  position: fixed;
+  bottom: 0;
+  left: 0;
 }
 
 body.dark .footer {
@@ -269,6 +273,15 @@ body.dark .footer {
 
 .footer a {
   color: #61dafb;
+}
+
+.footer .dataSources {
+  font-size: 10px;
+}
+
+.footer .dataSources a {
+  color: #888;
+  text-decoration: none;
 }
 
 .currencyDiv .plusIcon {

--- a/src/App.js
+++ b/src/App.js
@@ -44,7 +44,7 @@ function App() {
             {theme === "dark" ? "☀️" : "🌙"}
           </button>
           <button className="langToggle" onClick={toggleLanguage}>
-            {i18n.language === 'tr' ? 'EN' : 'TR'}
+            {i18n.language === 'tr' ? '🇬🇧' : '🇹🇷'}
           </button>
         </>
       )}

--- a/src/compononents/Footer.js
+++ b/src/compononents/Footer.js
@@ -10,7 +10,7 @@ function Footer() {
         <p>
           Developed by Mustafa Evleksiz - 2025 - v{packageJson.version}
         </p>
-        <p>
+        <p className="dataSources">
           {t('exchange_rates_from')} {" "}
           <a href="https://frankfurter.dev" target="_blank" rel="noreferrer">
             frankfurter.dev

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -4,7 +4,7 @@ import { initReactI18next } from 'react-i18next';
 const resources = {
   en: {
     translation: {
-      title: 'Currency Calculator',
+      title: 'Currency & Commodity Calculator',
       select_currency: 'Select currency',
       remove_confirm: 'Remove currency?',
       exchange_rates_from: 'Exchange rates from',
@@ -13,7 +13,7 @@ const resources = {
   },
   tr: {
     translation: {
-      title: 'D\u00f6viz Hesaplay\u0131c\u0131',
+      title: 'D\u00d6V\u0130Z - EMT\u0130A HESAPLAYICI',
       select_currency: 'Para birimi se\u00e7',
       remove_confirm: 'Para birimi kald\u0131r\u0131ls\u0131n m\u0131?',
       exchange_rates_from: 'Kur verileri',


### PR DESCRIPTION
## Summary
- localize title for Turkish and English
- use flags instead of text for language switcher
- position footer at bottom and shrink data source text
- show data source info with subdued links

## Testing
- `npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6883b94d93dc8327871778f263ec859f