### PR TITLE
Improve calendar style for dark mode and mobile

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -169,6 +169,9 @@ input[type="date"] {
   border: 1px solid #555;
   color: #fff;
   animation: fadeInScale 0.3s ease;
+  font-size: 16px;
+  border-radius: 8px;
+  width: 100%;
 }
 
 .react-datepicker__header {
@@ -196,7 +199,19 @@ body.dark .react-datepicker__day {
 
 body.dark .react-datepicker__day--disabled,
 body.dark .react-datepicker__day--outside-month {
-  color: #000;
+  color: #555;
+}
+
+.react-datepicker__day--selected,
+.react-datepicker__day--keyboard-selected {
+  background-color: #6c5ce7;
+  color: #fff;
+}
+
+@media (max-width: 576px) {
+  .react-datepicker {
+    font-size: 18px;
+  }
 }
 
 input[type="number"] {

--- a/src/compononents/Currency.js
+++ b/src/compononents/Currency.js
@@ -252,6 +252,13 @@ function Currency({ isSuper, onTitleClick }) {
   const [currencyTime, setCurrencyTime] = useState(today);
   const [showAdd, setShowAdd] = useState(false);
   const [baseIndex, setBaseIndex] = useState(0);
+  const [isMobile, setIsMobile] = useState(window.innerWidth <= 576);
+
+  useEffect(() => {
+    const handleResize = () => setIsMobile(window.innerWidth <= 576);
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
 
   const nextDayDisabled = currencyTime >= today;
   const nextMonthDisabled = currencyTime >= today;
@@ -470,6 +477,7 @@ function Currency({ isSuper, onTitleClick }) {
             minDate={new Date(MIN_DATE)}
             dateFormat="yyyy-MM-dd"
             showYearDropdown
+            withPortal={isMobile}
           />
           <Button onClick={() => changeDate(1)} disabled={nextDayDisabled}>
             {">"}
@@ -493,6 +501,7 @@ function Currency({ isSuper, onTitleClick }) {
           minDate={new Date(MIN_DATE)}
           dateFormat="yyyy-MM-dd"
           showYearDropdown
+          withPortal={isMobile}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- restyle DatePicker for better contrast in dark mode
- adjust DatePicker font sizes and radius
- use portal-based DatePicker on mobile screens

## Testing
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6883d2f3e26c8327a5155edea57311b3