### PR TITLE
Apply UI tweaks and default currencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "currencyconverter3",
-  "version": "7.25.1737",
+  "version": "7.25.1935",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "currencyconverter3",
-      "version": "7.25.1737",
+      "version": "7.25.1935",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "currencyconverter3",
-  "version": "7.25.1737",
+  "version": "7.25.1935",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",

--- a/src/App.css
+++ b/src/App.css
@@ -104,6 +104,10 @@ body.dark .currencyDiv {
   color: inherit;
   font-size: 20px;
   text-transform: uppercase;
+  border: 2px solid rgb(108, 92, 231);
+  display: inline-block;
+  padding: 4px 8px;
+  white-space: nowrap;
 }
 
 .currencyDiv button {
@@ -390,5 +394,9 @@ body.dark .footer {
   }
   .currencyDiv h1 {
     font-size: 18px;
+    border: 2px solid rgb(108, 92, 231);
+    display: inline-block;
+    padding: 4px 8px;
+    white-space: nowrap;
   }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -213,7 +213,7 @@ body.dark .react-datepicker__day--outside-month {
 }
 
 .react-datepicker__day:hover {
-  background-color: rgb(108, 92, 231);
+  background-color: rgb(108, 92, 231) !important;
   color: #fff;
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -208,7 +208,12 @@ body.dark .react-datepicker__day--outside-month {
 
 .react-datepicker__day--selected,
 .react-datepicker__day--keyboard-selected {
-  background-color: #6c5ce7;
+  background-color: rgb(108, 92, 231) !important;
+  color: #fff;
+}
+
+.react-datepicker__day:hover {
+  background-color: rgb(108, 92, 231);
   color: #fff;
 }
 

--- a/src/compononents/Currency.js
+++ b/src/compononents/Currency.js
@@ -244,7 +244,6 @@ function Currency({ isSuper, onTitleClick }) {
   const [currencies, setCurrencies] = useState([
     { code: "USD", amount: 1, rate: 1 },
     { code: "TRY", amount: 0, rate: 0 },
-    { code: "XAU", amount: 0, rate: 0 },
     { code: "AED", amount: 0, rate: 0 },
   ]);
   const MIN_DATE = "2013-04-01";

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -4,7 +4,7 @@ import { initReactI18next } from 'react-i18next';
 const resources = {
   en: {
     translation: {
-      title: 'Currency & Commodity Calculator',
+      title: 'CURRENCY-COMMODITY CALCULATOR',
       select_currency: 'Select currency/metal',
       remove_confirm: 'Remove currency?',
       exchange_rates_from: 'Exchange rates from',


### PR DESCRIPTION
## Summary
- default currencies are now USD, TRY, and AED
- style calculator title with a single-line framed header
- update English translation title

## Testing
- `CI=true npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6883d7a68c188327bc2baa8a852b35fe