### PR TITLE
UI polish and version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "currencyconverter3",
-  "version": "7.25.1935",
+  "version": "7.25.1952",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "currencyconverter3",
-      "version": "7.25.1935",
+      "version": "7.25.1952",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "currencyconverter3",
-  "version": "7.25.1952",
+  "version": "7.25.2001",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "currencyconverter3",
-      "version": "7.25.1952",
+      "version": "7.25.2001",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "currencyconverter3",
-  "version": "7.25.1952",
+  "version": "7.25.2001",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "currencyconverter3",
-  "version": "7.25.1935",
+  "version": "7.25.1952",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",

--- a/src/App.css
+++ b/src/App.css
@@ -105,9 +105,11 @@ body.dark .currencyDiv {
   font-size: 20px;
   text-transform: uppercase;
   border: 2px solid rgb(108, 92, 231);
-  display: inline-block;
+  display: block;
+  width: 100%;
   padding: 4px 8px;
   white-space: nowrap;
+  text-align: center;
 }
 
 .currencyDiv button {
@@ -176,11 +178,31 @@ input[type="date"] {
   font-size: 16px;
   border-radius: 8px;
   width: 100%;
+  box-sizing: border-box;
+  max-width: 100vw;
 }
 
 .react-datepicker__header {
   background-color: #444;
   border-bottom: 1px solid #555;
+}
+
+.react-datepicker__current-month,
+.react-datepicker-year-header {
+  color: rgb(108, 92, 231);
+}
+
+.react-datepicker__navigation-icon::before,
+.react-datepicker__year-read-view--down-arrow,
+.react-datepicker__month-read-view--down-arrow,
+.react-datepicker__month-year-read-view--down-arrow,
+.react-datepicker__navigation--years-previous .react-datepicker__navigation-icon::before,
+.react-datepicker__navigation--years-upcoming .react-datepicker__navigation-icon::before {
+  border-color: rgb(108, 92, 231);
+}
+
+.react-datepicker__year-option--selected {
+  color: rgb(108, 92, 231);
 }
 
 body.dark .react-datepicker {
@@ -398,10 +420,12 @@ body.dark .footer {
     padding: 2px 5px;
   }
   .currencyDiv h1 {
-    font-size: 18px;
+    font-size: 16px;
     border: 2px solid rgb(108, 92, 231);
-    display: inline-block;
+    display: block;
+    width: 100%;
     padding: 4px 8px;
     white-space: nowrap;
+    text-align: center;
   }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -192,6 +192,11 @@ input[type="date"] {
   color: rgb(108, 92, 231);
 }
 
+body.dark .react-datepicker__current-month,
+body.dark .react-datepicker-year-header {
+  color: rgb(108, 92, 231);
+}
+
 .react-datepicker__navigation-icon::before,
 .react-datepicker__year-read-view--down-arrow,
 .react-datepicker__month-read-view--down-arrow,
@@ -201,8 +206,14 @@ input[type="date"] {
   border-color: rgb(108, 92, 231);
 }
 
+.react-datepicker__year-option,
 .react-datepicker__year-option--selected {
   color: rgb(108, 92, 231);
+}
+
+.react-datepicker__navigation--years-previous,
+.react-datepicker__navigation--years-upcoming {
+  background-color: transparent;
 }
 
 body.dark .react-datepicker {


### PR DESCRIPTION
## Summary
- widen header border style and adjust font size on mobile
- tune datepicker visuals (month/year colors, arrow colors, check mark color)
- keep calendar from overflowing on mobile
- bump package version using update script

## Testing
- `npm install`
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6883df8d8688832799157bd7fc56358f