### PR TITLE
Fix usage parsing and improve add currency button

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -406,7 +406,7 @@ body.dark .footer {
   color: #0f9d58 !important;
   cursor: pointer;
   transition: transform 0.2s ease;
-  width: auto;
+  width: 100%;
   padding: 5px 20px;
 }
 

--- a/src/App.js
+++ b/src/App.js
@@ -45,7 +45,9 @@ function App() {
       );
       if (!resp.ok) throw new Error('Request failed');
       const data = await resp.json();
-      alert(`Remaining requests: ${data.usage.requests_remaining}`);
+      const usage = data.usage || data.data?.usage;
+      if (!usage) throw new Error('Malformed response');
+      alert(`Remaining requests: ${usage.requests_remaining}`);
     } catch {
       alert('Failed to fetch usage info');
     }

--- a/src/compononents/Currency.js
+++ b/src/compononents/Currency.js
@@ -484,7 +484,7 @@ function Currency({ isSuper, onTitleClick }) {
           className="plusIcon"
           onClick={() => setShowAdd(!showAdd)}
         >
-          ➕
+          {showAdd ? "➖" : "➕"}
         </Button>
       )}
       {isSuper ? (


### PR DESCRIPTION
## Summary
- handle new API response format for `/usage.json`
- toggle add currency button icon when dropdown is visible
- widen the add currency button to match currency rows

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6883ef07a65c8327847f1b1ef3f303ee