### PR TITLE
Add date presets and comparison view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "currencyconverter3",
-  "version": "7.25.2029",
+  "version": "7.25.2118",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "currencyconverter3",
-      "version": "7.25.2029",
+      "version": "7.25.2118",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "currencyconverter3",
-  "version": "7.25.2029",
+  "version": "7.25.2118",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",

--- a/src/App.css
+++ b/src/App.css
@@ -402,11 +402,11 @@ body.dark .footer {
 .currencyDiv .plusIcon {
   text-align: center;
   font-size: 1rem;
-  margin: 10px auto;
+  margin-left: auto;
   color: #0f9d58 !important;
   cursor: pointer;
   transition: transform 0.2s ease;
-  width: 100%;
+  width: auto;
   padding: 5px 20px;
 }
 
@@ -425,6 +425,25 @@ body.dark .footer {
 
 .minusIcon:hover {
   animation: scaleIcon 0.3s forwards;
+}
+
+.presetRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.compareInput {
+  width: 65%;
+}
+
+.compareMode .currencyRow input[type="text"] {
+  width: 45%;
+}
+
+.compareMode .compareInput {
+  width: 45%;
 }
 
 @keyframes scaleIcon {

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -9,6 +9,9 @@ const resources = {
       remove_confirm: 'Remove currency?',
       exchange_rates_from: 'Exchange rates from',
       commodities_from: 'Commodities from',
+      today: 'Today',
+      last_year: 'Last Year',
+      five_years_ago: '5 Years Ago',
     },
   },
   tr: {
@@ -18,6 +21,9 @@ const resources = {
       remove_confirm: 'Para birimi kald\u0131r\u0131ls\u0131n m\u0131?',
       exchange_rates_from: 'Kur verileri',
       commodities_from: 'Emtia verileri',
+      today: 'Bug\u00fcn',
+      last_year: 'Ge\u00e7en Y\u0131l',
+      five_years_ago: '5 Y\u0131l \u00d6nce',
     },
   },
 };


### PR DESCRIPTION
## Summary
- add new translation keys for preset buttons
- implement compare date functionality in `Currency` component
- show preset buttons and move add currency button
- style comparison and layout
- bump version with script

## Testing
- `npm install`
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6883f379080c8327a8cd96d38d4c16d8