### PR TITLE
Improve preset layout & super compare nav

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "currencyconverter3",
-  "version": "7.25.2118",
+  "version": "7.25.2155",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "currencyconverter3",
-      "version": "7.25.2118",
+      "version": "7.25.2155",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "currencyconverter3",
-  "version": "7.25.2118",
+  "version": "7.25.2155",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",

--- a/src/App.css
+++ b/src/App.css
@@ -429,9 +429,14 @@ body.dark .footer {
 
 .presetRow {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 10px;
   margin-top: 10px;
+}
+
+.presetRow button {
+  padding: 5px 20px;
 }
 
 .compareInput {
@@ -444,6 +449,16 @@ body.dark .footer {
 
 .compareMode .compareInput {
   width: 45%;
+}
+
+.dateRow {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.dateRow .react-datepicker-wrapper {
+  flex: 1;
 }
 
 @keyframes scaleIcon {
@@ -484,6 +499,13 @@ body.dark .footer {
   .dateNavigator button {
     font-size: 0.8rem;
     padding: 2px 5px;
+  }
+  .presetRow {
+    gap: 5px;
+  }
+  .presetRow button {
+    font-size: 0.6rem;
+    padding: 5px 20px;
   }
   .currencyDiv h1 {
     font-size: 16px;

--- a/src/compononents/Currency.js
+++ b/src/compononents/Currency.js
@@ -295,6 +295,13 @@ function Currency({ isSuper, onTitleClick }) {
   const prevMonthDisabled = currencyTime <= MIN_DATE;
   const prevYearDisabled = currencyTime <= MIN_DATE;
 
+  const compareNextDayDisabled = !compareTime || compareTime >= today;
+  const compareNextMonthDisabled = !compareTime || compareTime >= today;
+  const compareNextYearDisabled = !compareTime || compareTime >= today;
+  const comparePrevDayDisabled = !compareTime || compareTime <= MIN_DATE;
+  const comparePrevMonthDisabled = !compareTime || compareTime <= MIN_DATE;
+  const comparePrevYearDisabled = !compareTime || compareTime <= MIN_DATE;
+
   const changeDate = (days) => {
     const d = new Date(currencyTime);
     d.setDate(d.getDate() + days);
@@ -320,6 +327,36 @@ function Currency({ isSuper, onTitleClick }) {
     if (years > 0 && newDate > today) newDate = today;
     if (years < 0 && newDate < MIN_DATE) newDate = MIN_DATE;
     handleDateSelection({ target: { value: newDate } });
+  };
+
+  const changeCompareDate = (days) => {
+    if (!compareTime) return;
+    const d = new Date(compareTime);
+    d.setDate(d.getDate() + days);
+    let newDate = d.toISOString().slice(0, 10);
+    if (days < 0 && newDate < MIN_DATE) newDate = MIN_DATE;
+    if (days > 0 && newDate > today) return;
+    setCompareTime(newDate);
+  };
+
+  const changeCompareMonth = (months) => {
+    if (!compareTime) return;
+    const d = new Date(compareTime);
+    d.setMonth(d.getMonth() + months);
+    let newDate = d.toISOString().slice(0, 10);
+    if (months > 0 && newDate > today) newDate = today;
+    if (months < 0 && newDate < MIN_DATE) newDate = MIN_DATE;
+    setCompareTime(newDate);
+  };
+
+  const changeCompareYear = (years) => {
+    if (!compareTime) return;
+    const d = new Date(compareTime);
+    d.setFullYear(d.getFullYear() + years);
+    let newDate = d.toISOString().slice(0, 10);
+    if (years > 0 && newDate > today) newDate = today;
+    if (years < 0 && newDate < MIN_DATE) newDate = MIN_DATE;
+    setCompareTime(newDate);
   };
 
   const handleDateSelection = (e) => {
@@ -544,10 +581,68 @@ function Currency({ isSuper, onTitleClick }) {
         )}
       </div>
       {isSuper ? (
-        <div className="dateNavigator">
-          <Button onClick={() => changeYear(-1)} disabled={prevYearDisabled}>{"<<<"}</Button>
-          <Button onClick={() => changeMonth(-1)} disabled={prevMonthDisabled}>{"<<"}</Button>
-          <Button onClick={() => changeDate(-1)} disabled={prevDayDisabled}>{"<"}</Button>
+        <>
+          <div className="dateNavigator">
+            <Button onClick={() => changeYear(-1)} disabled={prevYearDisabled}>{"<<<"}</Button>
+            <Button onClick={() => changeMonth(-1)} disabled={prevMonthDisabled}>{"<<"}</Button>
+            <Button onClick={() => changeDate(-1)} disabled={prevDayDisabled}>{"<"}</Button>
+            <DatePicker
+              selected={new Date(currencyTime)}
+              onChange={(date) =>
+                handleDateSelection({
+                  target: { value: date.toISOString().slice(0, 10) },
+                })
+              }
+              maxDate={new Date()}
+              minDate={new Date(MIN_DATE)}
+              dateFormat="yyyy-MM-dd"
+              showYearDropdown
+              dropdownMode="select"
+              inputReadOnly
+              withPortal={isMobile}
+            />
+            <Button onClick={() => changeDate(1)} disabled={nextDayDisabled}>
+              {">"}
+            </Button>
+            <Button onClick={() => changeMonth(1)} disabled={nextMonthDisabled}>
+              {">>"}
+            </Button>
+            <Button onClick={() => changeYear(1)} disabled={nextYearDisabled}>
+              {">>>"}
+            </Button>
+          </div>
+          {compareTime && (
+            <div className="dateNavigator">
+              <Button onClick={() => changeCompareYear(-1)} disabled={comparePrevYearDisabled}>{"<<<"}</Button>
+              <Button onClick={() => changeCompareMonth(-1)} disabled={comparePrevMonthDisabled}>{"<<"}</Button>
+              <Button onClick={() => changeCompareDate(-1)} disabled={comparePrevDayDisabled}>{"<"}</Button>
+              <DatePicker
+                selected={new Date(compareTime)}
+                onChange={(date) =>
+                  setCompareTime(date.toISOString().slice(0, 10))
+                }
+                maxDate={new Date()}
+                minDate={new Date(MIN_DATE)}
+                dateFormat="yyyy-MM-dd"
+                showYearDropdown
+                dropdownMode="select"
+                inputReadOnly
+                withPortal={isMobile}
+              />
+              <Button onClick={() => changeCompareDate(1)} disabled={compareNextDayDisabled}>
+                {">"}
+              </Button>
+              <Button onClick={() => changeCompareMonth(1)} disabled={compareNextMonthDisabled}>
+                {">>"}
+              </Button>
+              <Button onClick={() => changeCompareYear(1)} disabled={compareNextYearDisabled}>
+                {">>>"}
+              </Button>
+            </div>
+          )}
+        </>
+      ) : (
+        <div className="dateRow">
           <DatePicker
             selected={new Date(currencyTime)}
             onChange={(date) =>
@@ -563,51 +658,23 @@ function Currency({ isSuper, onTitleClick }) {
             inputReadOnly
             withPortal={isMobile}
           />
-          <Button onClick={() => changeDate(1)} disabled={nextDayDisabled}>
-            {">"}
-          </Button>
-          <Button onClick={() => changeMonth(1)} disabled={nextMonthDisabled}>
-            {">>"}
-          </Button>
-          <Button onClick={() => changeYear(1)} disabled={nextYearDisabled}>
-            {">>>"}
-          </Button>
+          {compareTime && (
+            <DatePicker
+              selected={new Date(compareTime)}
+              onChange={(date) =>
+                setCompareTime(date.toISOString().slice(0, 10))
+              }
+              maxDate={new Date()}
+              minDate={new Date(MIN_DATE)}
+              dateFormat="yyyy-MM-dd"
+              showYearDropdown
+              dropdownMode="select"
+              inputReadOnly
+              withPortal={isMobile}
+            />
+          )}
         </div>
-      ) : null}
-      <div className="dateRow">
-        {!isSuper && (
-          <DatePicker
-            selected={new Date(currencyTime)}
-            onChange={(date) =>
-              handleDateSelection({
-                target: { value: date.toISOString().slice(0, 10) },
-              })
-            }
-            maxDate={new Date()}
-            minDate={new Date(MIN_DATE)}
-            dateFormat="yyyy-MM-dd"
-            showYearDropdown
-            dropdownMode="select"
-            inputReadOnly
-            withPortal={isMobile}
-          />
-        )}
-        {compareTime && (
-          <DatePicker
-            selected={new Date(compareTime)}
-            onChange={(date) =>
-              setCompareTime(date.toISOString().slice(0, 10))
-            }
-            maxDate={new Date()}
-            minDate={new Date(MIN_DATE)}
-            dateFormat="yyyy-MM-dd"
-            showYearDropdown
-            dropdownMode="select"
-            inputReadOnly
-            withPortal={isMobile}
-          />
-        )}
-      </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- allow preset buttons to wrap onto two rows and match plus icon height
- add navigation controls for compare date in super mode
- bump version using update script

## Testing
- `npm install`
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6883f7cf9fb48327ae789314478a2bd2