### PR TITLE
Fix preset row button height

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -430,7 +430,7 @@ body.dark .footer {
 .presetRow {
   display: flex;
   flex-wrap: nowrap;
-  align-items: center;
+  align-items: stretch;
   gap: 10px;
   margin-top: 10px;
 }
@@ -474,6 +474,10 @@ body.dark .footer {
 
 .dateRow .react-datepicker-wrapper {
   flex: 1;
+}
+
+.dateRow.single .react-datepicker-wrapper {
+  flex-basis: 100%;
 }
 
 @keyframes scaleIcon {

--- a/src/compononents/Currency.js
+++ b/src/compononents/Currency.js
@@ -659,7 +659,7 @@ function Currency({ isSuper, onTitleClick }) {
           )}
         </>
       ) : (
-        <div className="dateRow">
+        <div className={`dateRow${compareTime ? '' : ' single'}`}>
           <DatePicker
             selected={new Date(currencyTime)}
             onChange={(date) =>


### PR DESCRIPTION
## Summary
- keep buttons aligned in the preset row
- stretch date picker when comparison mode is off

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6884050ced0483279692c6780d3b3de1