### PR TITLE
Fix date row layout with single picker

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -470,6 +470,11 @@ body.dark .footer {
   display: flex;
   gap: 10px;
   align-items: center;
+  width: 100%;
+}
+
+.dateRow.single {
+  display: block;
 }
 
 .dateRow .react-datepicker-wrapper {
@@ -477,7 +482,8 @@ body.dark .footer {
 }
 
 .dateRow.single .react-datepicker-wrapper {
-  flex-basis: 100%;
+  flex: 1 0 100%;
+  width: 100%;
 }
 
 @keyframes scaleIcon {


### PR DESCRIPTION
## Summary
- expand `.dateRow.single` to block layout so the remaining picker fills the row

## Testing
- `npm test -- --passWithNoTests --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68848937705c832796dee375d36e407d