### PR TITLE
Enhance commodities display and animations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "currencyconverter3",
-  "version": "7.25.2223",
+  "version": "7.26.0838",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "currencyconverter3",
-      "version": "7.25.2223",
+      "version": "7.26.0838",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "currencyconverter3",
-  "version": "7.25.2223",
+  "version": "7.26.0838",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",

--- a/src/App.css
+++ b/src/App.css
@@ -315,12 +315,18 @@ select {
 }
 
 .currencyRow input[type="text"] {
-  width: 65%;
+  width: 60%;
 }
 
 .currencyRow select {
-  width: 30%;
+  width: 25%;
   font-size: 14px;
+}
+
+.flagIcon {
+  width: 24px;
+  text-align: center;
+  font-size: 1.3rem;
 }
 
 button {
@@ -448,16 +454,19 @@ body.dark .footer {
   flex: 1;
 }
 
+
 .compareInput {
-  width: 65%;
+  width: 60%;
 }
+
 
 .compareMode .currencyRow input[type="text"] {
-  width: 45%;
+  width: 40%;
 }
 
+
 .compareMode .compareInput {
-  width: 45%;
+  width: 40%;
 }
 
 @media (max-width: 576px) {

--- a/src/compononents/Currency.js
+++ b/src/compononents/Currency.js
@@ -501,6 +501,7 @@ function Currency({ isSuper, onTitleClick }) {
                 animate={{ opacity: 1, y: 0 }}
                 exit={{ opacity: 0, y: 10 }}
               >
+                <span className="flagIcon">{getFlag(c.code)}</span>
                 <Form.Select
                   value={c.code}
                   onChange={(e) => handleCurrencyChange(idx, e.target.value)}
@@ -538,6 +539,8 @@ function Currency({ isSuper, onTitleClick }) {
                 )}
                 {currencies.length >= 3 && (
                   <Button
+                    as={motion.button}
+                    whileTap={{ scale: 0.9 }}
                     variant="danger"
                     className="minusIcon"
                     onClick={() => handleRemoveCurrency(idx)}
@@ -577,16 +580,18 @@ function Currency({ isSuper, onTitleClick }) {
       </div>
       <div className="presetRow">
         {currencyTime !== today && (
-          <Button onClick={handleToday}>{t('today')}</Button>
+          <Button as={motion.button} whileTap={{ scale: 0.9 }} onClick={handleToday}>{t('today')}</Button>
         )}
-        <Button onClick={handleLastYear}>
+        <Button as={motion.button} whileTap={{ scale: 0.9 }} onClick={handleLastYear}>
           {formatTwoLines(t('last_year'))}
         </Button>
-        <Button onClick={handleFiveYears}>
+        <Button as={motion.button} whileTap={{ scale: 0.9 }} onClick={handleFiveYears}>
           {formatTwoLines(t('five_years_ago'))}
         </Button>
         {currencies.length < 8 && (
           <Button
+            as={motion.button}
+            whileTap={{ scale: 0.9 }}
             variant="success"
             className="plusIcon"
             onClick={() => setShowAdd(!showAdd)}
@@ -598,9 +603,9 @@ function Currency({ isSuper, onTitleClick }) {
       {isSuper ? (
         <>
           <div className="dateNavigator">
-            <Button onClick={() => changeYear(-1)} disabled={prevYearDisabled}>{"<<<"}</Button>
-            <Button onClick={() => changeMonth(-1)} disabled={prevMonthDisabled}>{"<<"}</Button>
-            <Button onClick={() => changeDate(-1)} disabled={prevDayDisabled}>{"<"}</Button>
+            <Button as={motion.button} whileTap={{ scale: 0.9 }} onClick={() => changeYear(-1)} disabled={prevYearDisabled}>{"<<<"}</Button>
+            <Button as={motion.button} whileTap={{ scale: 0.9 }} onClick={() => changeMonth(-1)} disabled={prevMonthDisabled}>{"<<"}</Button>
+            <Button as={motion.button} whileTap={{ scale: 0.9 }} onClick={() => changeDate(-1)} disabled={prevDayDisabled}>{"<"}</Button>
             <DatePicker
               selected={new Date(currencyTime)}
               onChange={(date) =>
@@ -617,21 +622,21 @@ function Currency({ isSuper, onTitleClick }) {
               onFocus={(e) => e.target.blur()}
               withPortal={isMobile}
             />
-            <Button onClick={() => changeDate(1)} disabled={nextDayDisabled}>
+            <Button as={motion.button} whileTap={{ scale: 0.9 }} onClick={() => changeDate(1)} disabled={nextDayDisabled}>
               {">"}
             </Button>
-            <Button onClick={() => changeMonth(1)} disabled={nextMonthDisabled}>
+            <Button as={motion.button} whileTap={{ scale: 0.9 }} onClick={() => changeMonth(1)} disabled={nextMonthDisabled}>
               {">>"}
             </Button>
-            <Button onClick={() => changeYear(1)} disabled={nextYearDisabled}>
+            <Button as={motion.button} whileTap={{ scale: 0.9 }} onClick={() => changeYear(1)} disabled={nextYearDisabled}>
               {">>>"}
             </Button>
           </div>
           {compareTime && (
             <div className="dateNavigator">
-              <Button onClick={() => changeCompareYear(-1)} disabled={comparePrevYearDisabled}>{"<<<"}</Button>
-              <Button onClick={() => changeCompareMonth(-1)} disabled={comparePrevMonthDisabled}>{"<<"}</Button>
-              <Button onClick={() => changeCompareDate(-1)} disabled={comparePrevDayDisabled}>{"<"}</Button>
+              <Button as={motion.button} whileTap={{ scale: 0.9 }} onClick={() => changeCompareYear(-1)} disabled={comparePrevYearDisabled}>{"<<<"}</Button>
+              <Button as={motion.button} whileTap={{ scale: 0.9 }} onClick={() => changeCompareMonth(-1)} disabled={comparePrevMonthDisabled}>{"<<"}</Button>
+              <Button as={motion.button} whileTap={{ scale: 0.9 }} onClick={() => changeCompareDate(-1)} disabled={comparePrevDayDisabled}>{"<"}</Button>
               <DatePicker
                 selected={new Date(compareTime)}
                 onChange={(date) =>
@@ -646,13 +651,13 @@ function Currency({ isSuper, onTitleClick }) {
                 onFocus={(e) => e.target.blur()}
                 withPortal={isMobile}
               />
-              <Button onClick={() => changeCompareDate(1)} disabled={compareNextDayDisabled}>
+              <Button as={motion.button} whileTap={{ scale: 0.9 }} onClick={() => changeCompareDate(1)} disabled={compareNextDayDisabled}>
                 {">"}
               </Button>
-              <Button onClick={() => changeCompareMonth(1)} disabled={compareNextMonthDisabled}>
+              <Button as={motion.button} whileTap={{ scale: 0.9 }} onClick={() => changeCompareMonth(1)} disabled={compareNextMonthDisabled}>
                 {">>"}
               </Button>
-              <Button onClick={() => changeCompareYear(1)} disabled={compareNextYearDisabled}>
+              <Button as={motion.button} whileTap={{ scale: 0.9 }} onClick={() => changeCompareYear(1)} disabled={compareNextYearDisabled}>
                 {">>>"}
               </Button>
             </div>


### PR DESCRIPTION
## Summary
- show flag icons next to each currency/commodity
- animate preset and navigation buttons
- adjust layout for new icons
- bump app version

## Testing
- `npm install`
- `CI=true npm test --silent -- --passWithNoTests`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6884937d59c4832794dd9cd5d4e676d4