### PR TITLE
feat: add navigation bar with theme and language toggles

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -328,32 +328,28 @@ button {
   font-size: 1.2rem;
 }
 
-.themeToggle {
-  width: auto;
-  position: absolute;
-  top: 10px;
-  right: 10px;
+.topNav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 10px;
+  background: transparent;
+  z-index: 1000;
 }
 
-.langToggle {
+.topNav button {
   width: auto;
-  position: absolute;
-  top: 10px;
-  right: 60px;
 }
 
-.cacheClear {
-  width: auto;
-  position: absolute;
-  top: 10px;
-  right: 110px;
-}
-
+.themeToggle,
+.langToggle,
+.cacheClear,
 .usageCheck {
   width: auto;
-  position: absolute;
-  top: 10px;
-  right: 160px;
 }
 
 #getUsdCurrencyBtn,

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
 import "./App.css";
 import Currency from "./compononents/Currency";
 import Footer from "./compononents/Footer";
+import Navbar from "./compononents/Navbar";
 
 import { useEffect, useState } from "react";
 import { useTranslation } from 'react-i18next';
@@ -59,18 +60,14 @@ function App() {
 
   return (
     <div className="container">
-        {superMode && (
-        <>
-          <button className="themeToggle" onClick={toggleTheme}>
-            {theme === "dark" ? "☀️" : "🌙"}
-          </button>
-          <button className="langToggle" onClick={toggleLanguage}>
-            {i18n.language === 'tr' ? '🇬🇧' : '🇹🇷'}
-          </button>
-          <button className="cacheClear" onClick={clearCache}>🗑️</button>
-          <button className="usageCheck" onClick={checkUsage}>📈</button>
-        </>
-      )}
+      <Navbar
+        theme={theme}
+        toggleTheme={toggleTheme}
+        toggleLanguage={toggleLanguage}
+        superMode={superMode}
+        clearCache={clearCache}
+        checkUsage={checkUsage}
+      />
       <Currency isSuper={superMode} onTitleClick={handleTitleClick} />
       <Footer />
     </div>

--- a/src/compononents/Navbar.js
+++ b/src/compononents/Navbar.js
@@ -1,0 +1,24 @@
+import React from "react";
+import { useTranslation } from 'react-i18next';
+
+function Navbar({ theme, toggleTheme, toggleLanguage, superMode, clearCache, checkUsage }) {
+  const { i18n } = useTranslation();
+  return (
+    <nav className="topNav">
+      <button className="themeToggle" onClick={toggleTheme}>
+        {theme === 'dark' ? '☀️' : '🌙'}
+      </button>
+      <button className="langToggle" onClick={toggleLanguage}>
+        {i18n.language === 'tr' ? '🇬🇧' : '🇹🇷'}
+      </button>
+      {superMode && (
+        <>
+          <button className="cacheClear" onClick={clearCache}>🗑️</button>
+          <button className="usageCheck" onClick={checkUsage}>📈</button>
+        </>
+      )}
+    </nav>
+  );
+}
+
+export default Navbar;


### PR DESCRIPTION
## Summary
- add dedicated Navbar with theme and language toggles
- surface cache and usage controls when super mode enabled
- style top navigation bar for fixed positioning and responsiveness

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_688f27aa233c8327bed66b4668e6590a