### PR TITLE
feat: enhance navigation and responsive styling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,14 @@
       content="Currency and commodity converter with historical data"
     />
 
+    <!-- Minimal sans-serif font for clean typography -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
+
     <title>Currency-Commodity Converter</title>
   </head>
   <body>

--- a/src/App.css
+++ b/src/App.css
@@ -46,7 +46,7 @@
 
 body {
   background-color: #f3f3f3;
-  font-family: "Arial", sans-serif;
+  font-family: 'Inter', sans-serif;
   color: #333;
   margin: 0;
   padding: 0;
@@ -58,6 +58,9 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  padding: 1rem;
+  max-width: 960px;
+  margin: 0 auto;
   padding-bottom: 60px;
 }
 
@@ -77,17 +80,21 @@ body.dark {
 }
 
 .currencyDiv {
-  width: 90vw;
-  margin: 40px auto;
+  width: 100%;
+  max-width: 600px;
+  margin: 1.5rem auto;
   background-color: #ffffff;
   border-radius: 8px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
-  margin-bottom: 20px;
-  flex: 0 1 calc(50% - 20px);
   padding: 20px;
   position: relative;
   transition: transform 0.3s ease;
-  max-width: 700px;
+}
+
+@media (min-width: 768px) {
+  .currencyDiv {
+    padding: 40px;
+  }
 }
 
 body.dark .currencyDiv {
@@ -115,15 +122,17 @@ body.dark .currencyDiv {
 .currencyDiv button {
   background-color: #6c5ce7;
   color: #ffffff;
-  padding: 10px 20px;
+  padding: 12px 20px;
   border: none;
   border-radius: 5px;
   cursor: pointer;
-  transition: background-color 0.3s ease;
+  transition: background-color 0.3s ease, transform 0.2s ease;
+  min-height: 44px;
 }
 
 .currencyDiv button:hover {
   background-color: #5a51cc;
+  transform: scale(1.02);
 }
 
 .currencyDiv p {
@@ -335,6 +344,7 @@ button {
   width: 100%;
   display: flex;
   justify-content: flex-end;
+  align-items: center;
   gap: 10px;
   padding: 10px;
   background: transparent;
@@ -342,14 +352,24 @@ button {
 }
 
 .topNav button {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  padding: 0.5rem;
   width: auto;
+  min-width: 44px;
+  min-height: 44px;
+  cursor: pointer;
+  transition: transform 0.2s ease;
 }
 
-.themeToggle,
-.langToggle,
-.cacheClear,
-.usageCheck {
-  width: auto;
+.topNav button:hover {
+  transform: scale(1.1);
+}
+
+.navActions {
+  display: flex;
+  gap: 10px;
 }
 
 #getUsdCurrencyBtn,

--- a/src/compononents/Navbar.js
+++ b/src/compononents/Navbar.js
@@ -1,22 +1,55 @@
 import React from "react";
 import { useTranslation } from 'react-i18next';
+import { motion } from "framer-motion";
 
 function Navbar({ theme, toggleTheme, toggleLanguage, superMode, clearCache, checkUsage }) {
   const { i18n } = useTranslation();
+
+  const iconProps = {
+    whileHover: { scale: 1.1 },
+    whileTap: { scale: 0.9 }
+  };
+
   return (
-    <nav className="topNav">
-      <button className="themeToggle" onClick={toggleTheme}>
-        {theme === 'dark' ? '☀️' : '🌙'}
-      </button>
-      <button className="langToggle" onClick={toggleLanguage}>
-        {i18n.language === 'tr' ? '🇬🇧' : '🇹🇷'}
-      </button>
-      {superMode && (
-        <>
-          <button className="cacheClear" onClick={clearCache}>🗑️</button>
-          <button className="usageCheck" onClick={checkUsage}>📈</button>
-        </>
-      )}
+    <nav className="topNav" aria-label="main navigation">
+      <div className="navActions">
+        {superMode && (
+          <>
+            <motion.button
+              className="themeToggle"
+              aria-label="Toggle theme"
+              onClick={toggleTheme}
+              {...iconProps}
+            >
+              {theme === 'dark' ? '☀️' : '🌙'}
+            </motion.button>
+            <motion.button
+              className="langToggle"
+              aria-label="Toggle language"
+              onClick={toggleLanguage}
+              {...iconProps}
+            >
+              {i18n.language === 'tr' ? '🇬🇧' : '🇹🇷'}
+            </motion.button>
+            <motion.button
+              className="cacheClear"
+              aria-label="Clear cache"
+              onClick={clearCache}
+              {...iconProps}
+            >
+              🗑️
+            </motion.button>
+            <motion.button
+              className="usageCheck"
+              aria-label="Check usage"
+              onClick={checkUsage}
+              {...iconProps}
+            >
+              📈
+            </motion.button>
+          </>
+        )}
+      </div>
     </nav>
   );
 }


### PR DESCRIPTION
## Summary
- add Inter font and minimal typography baseline
- convert navbar to icon-based navigation with motion animations and accessibility labels
- refine layout and buttons for mobile-first responsive design
- remove home button and limit nav controls to super mode only

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_688f3623340c8327a25db911af7debb5